### PR TITLE
Setup testing env and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 install: "pip install -r requirements.txt"
 
 # command to run tests
-script: pytest
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+
+# command to install dependencies
+install: "pip install -r requirements.txt"
+
+# command to run tests
+script: pytest

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# qabel-accounting
-Qabel Accounting Server
+# Qabel Accounting Server
+
+[![Build Status](https://travis-ci.org/Qabel/qabel-accounting.svg?branch=master)](https://travis-ci.org/Qabel/qabel-accounting)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,2 @@
+import pytest
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=qabel_id.settings

--- a/qabel_id/test_setup.py
+++ b/qabel_id/test_setup.py
@@ -1,0 +1,3 @@
+
+def test_failure():
+    assert False

--- a/qabel_id/test_setup.py
+++ b/qabel_id/test_setup.py
@@ -1,3 +1,0 @@
-
-def test_failure():
-    assert False

--- a/qabel_provider/test_admin.py
+++ b/qabel_provider/test_admin.py
@@ -1,0 +1,4 @@
+
+def test_an_admin_view(admin_client):
+    response = admin_client.get('/admin/')
+    assert response.status_code == 200

--- a/qabel_provider/tests.py
+++ b/qabel_provider/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.8.4
 py==1.4.30
 pytest==2.8.0
+pytest-django==2.8.0


### PR DESCRIPTION
This sets up a testing environment based on py.test and pytest-django. It includes a single test that only tests if the admin interface is reachable by an admin user.

The build-badge from Travis CI is included in the README