### PR TITLE
Use django-rest-auth instead of rolling our own auth

### DIFF
--- a/qabel_id/settings.py
+++ b/qabel_id/settings.py
@@ -38,6 +38,8 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
+    'rest_auth',
     'qabel_provider',
 )
 

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -18,12 +18,6 @@ from django.contrib import admin
 from qabel_provider import views
 
 # noinspection PyCallByClass
-user = views.UserViewSet.as_view({
-    'get': 'retrieve',
-    'patch': 'partial_update',
-})
-
-# noinspection PyCallByClass
 profile = views.ProfileViewSet.as_view({
     'get': 'retrieve',
 })
@@ -31,14 +25,13 @@ profile = views.ProfileViewSet.as_view({
 rest_urls = [
     url(r'^$', views.api_root, name='api-root'),
     url(r'^profile/', profile, name='api-profile'),
-    url(r'^user/', user, name='api-user'),
     url(r'^token/', views.token, name='api-token'),
+    url(r'^auth/', include('rest_auth.urls'))
 ]
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url('^accounts/', include('django.contrib.auth.urls')),
     url('^accounts/profile', views.profile),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/v0/', include(rest_urls))
 ]

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -13,16 +13,16 @@ def user_client(api_client, user):
 
 
 def test_login(api_client, user):
-    response = api_client.post('/api-auth/login', {'username': user.username, 'password': 'password'})
-    # redirect to profile page which we can ignore.
-    assert response.status_code == 301
+    response = api_client.post('/api/v0/auth/login/', {'username': user.username, 'password': 'password'})
+    assert "key" in loads(response.content)
 
 
 def test_get_user(api_client, user):
     api_client.force_authenticate(user)
-    response = api_client.get('/api/v0/user/')
+    response = api_client.get('/api/v0/auth/user/')
     assert response.status_code == 200
-    assert {"username": "qabel_user", "email": "qabeluser@example.com"}\
+    assert {"first_name": "", "last_name": "",
+            "username": "qabel_user", "email": "qabeluser@example.com"}\
         == loads(response.content)
 
 
@@ -42,22 +42,9 @@ def test_get_own_user(api_client, user):
     from django.contrib.auth.models import User
     other_user = User.objects.create_user('foobar')
     api_client.force_authenticate(other_user)
-    response = api_client.get('/api/v0/user/')
-    assert {"username": "foobar", "email": ""}\
+    response = api_client.get('/api/v0/auth/user/')
+    assert {"username": "foobar", "email": "", "first_name": "", "last_name": ""}\
         == loads(response.content)
-
-
-def test_update_email(user_client):
-    response = user_client.patch('/api/v0/user/', {'email': 'foo@example.com'})
-    assert response.status_code == 200
-    response = user_client.get('/api/v0/user/')
-    assert {"username": "qabel_user", "email": "foo@example.com"}\
-        == loads(response.content)
-
-
-def test_verify_email(user_client):
-    response = user_client.patch('/api/v0/user/', {'email': 'invalid'})
-    assert response.status_code == 400
 
 
 def test_get_federation_token(user_client):

--- a/qabel_provider/views.py
+++ b/qabel_provider/views.py
@@ -13,19 +13,6 @@ def profile(request):
     return render(request, 'accounts/profile.html')
 
 
-class UserViewSet(mixins.RetrieveModelMixin,
-                  mixins.UpdateModelMixin,
-                  viewsets.GenericViewSet):
-    """
-    API endpoint that allows users to be viewed or edited.
-    """
-    serializer_class = UserSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-    def get_object(self):
-        return self.request.user
-
-
 class ProfileViewSet(mixins.RetrieveModelMixin,
                      mixins.UpdateModelMixin,
                      viewsets.GenericViewSet):
@@ -50,11 +37,16 @@ def token(request):
                                           900),
                     status=201)
 
-
 @api_view(('GET',))
 def api_root(request, format=None):
     return Response({
         'token': reverse('api-token', request=request, format=format),
-        'user': reverse('api-user', request=request, format=format),
         'profile': reverse('api-profile', request=request, format=format),
+        'login': reverse('rest_login', request=request, format=format),
+        'logout': reverse('rest_logout', request=request, format=format),
+        'user': reverse('rest_user_details', request=request, format=format),
+        'password_change': reverse('rest_password_change', request=request, format=format),
+        'password_reset': reverse('rest_password_reset', request=request, format=format),
+        'password_confirm': reverse('rest_password_reset_confirm', request=request, format=format),
+
     })

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-splinter==1.7.0
 djangorestframework==3.2.4
 Markdown==2.6.2
 django-filter==0.11.0
+django-rest-auth==0.5.0


### PR DESCRIPTION
django-rest-auth provides views to login, view user details and handle password resets. It also allows us to later easily switch to something like OAuth2.