### PR TITLE
Enable token auth

### DIFF
--- a/qabel_id/settings.py
+++ b/qabel_id/settings.py
@@ -85,6 +85,14 @@ DATABASES = {
     }
 }
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    )
+}
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -35,7 +35,7 @@ def test_get_profile(api_client, user):
 
 def test_anonymous_profile(api_client):
     response = api_client.get('/api/v0/profile/')
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_get_own_user(api_client, user):


### PR DESCRIPTION
Instead of just allowing session auth, the simpler token auth is now enabled.

At `/api/v0/auth/login` a user can request an authentication token which he then has to include in his headers to authenticate (`Authentication: Token <the token>`).