### PR TITLE
Include S3 prefix and bucket in the user profile

### DIFF
--- a/qabel_provider/aws.py
+++ b/qabel_provider/aws.py
@@ -19,7 +19,8 @@ class Policy:
                     "s3:ListBucket",
                 ],
                 "Resource": [
-                    "arn:aws:s3:::qabel/" + self.user.profile.prefix
+                    "arn:aws:s3:::{}/{}".format(self.user.profile.bucket,
+                                                self.user.profile.prefix)
                 ]
             })
 

--- a/qabel_provider/aws.py
+++ b/qabel_provider/aws.py
@@ -19,15 +19,12 @@ class Policy:
                     "s3:ListBucket",
                 ],
                 "Resource": [
-                    "arn:aws:s3:::qabel/" + self._user_prefix()
+                    "arn:aws:s3:::qabel/" + self.user.profile.prefix
                 ]
             })
 
     def append(self, statement):
         self.policy['Statement'].append(statement)
-
-    def _user_prefix(self):
-        return 'user/{0}/'.format(self.user.id)
 
     @property
     def json(self):

--- a/qabel_provider/models.py
+++ b/qabel_provider/models.py
@@ -8,6 +8,10 @@ class Profile(models.Model):
     user = models.OneToOneField(User, primary_key=True, on_delete=models.CASCADE)
     quota = models.PositiveIntegerField(verbose_name="Storage quota", default=0)
 
+    @property
+    def prefix(self):
+        return 'user/{0}/'.format(self.user.id)
+
 
 @receiver(post_save, sender=User)
 def create_profile_for_new_user(sender, created, instance, **kwargs):

--- a/qabel_provider/models.py
+++ b/qabel_provider/models.py
@@ -8,6 +8,8 @@ class Profile(models.Model):
     user = models.OneToOneField(User, primary_key=True, on_delete=models.CASCADE)
     quota = models.PositiveIntegerField(verbose_name="Storage quota", default=0)
 
+    bucket = 'qabel'
+
     @property
     def prefix(self):
         return 'user/{0}/'.format(self.user.id)

--- a/qabel_provider/serializers.py
+++ b/qabel_provider/serializers.py
@@ -14,8 +14,9 @@ class UserSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.ModelSerializer):
 
     prefix = serializers.CharField(read_only=True)
+    bucket = serializers.CharField(read_only=True)
 
     class Meta:
         model = Profile
-        fields = ('quota', 'prefix')
+        fields = ('quota', 'prefix', 'bucket')
 

--- a/qabel_provider/serializers.py
+++ b/qabel_provider/serializers.py
@@ -13,7 +13,9 @@ class UserSerializer(serializers.ModelSerializer):
 
 class ProfileSerializer(serializers.ModelSerializer):
 
+    prefix = serializers.CharField(read_only=True)
+
     class Meta:
         model = Profile
-        fields = ('quota',)
+        fields = ('quota', 'prefix')
 

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -30,7 +30,9 @@ def test_get_profile(api_client, user):
     api_client.force_authenticate(user)
     response = api_client.get('/api/v0/profile/')
     assert response.status_code == 200
-    assert {"quota": 0} == loads(response.content)
+    profile = loads(response.content)
+    assert 0 == profile['quota']
+    assert user.profile.prefix == profile['prefix']
 
 
 def test_anonymous_profile(api_client):

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -33,6 +33,7 @@ def test_get_profile(api_client, user):
     profile = loads(response.content)
     assert 0 == profile['quota']
     assert user.profile.prefix == profile['prefix']
+    assert 'qabel' == profile['bucket']
 
 
 def test_anonymous_profile(api_client):


### PR DESCRIPTION
Calculate the prefix and the bucket on S3 directly in the profile class of the user. Both the prefix and the bucket are read only.

This enables the easy integration into the REST resource.