### PR TITLE
Remove quota, reimplemented auth

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,7 @@
 import pytest
-
 from django.contrib.auth.models import User
-from qabel_provider.models import Prefix
 from rest_framework.test import APIClient
+from rest_framework.authtoken.models import Token
 
 USERNAME = 'qabel_user'
 
@@ -21,18 +20,13 @@ def user(db):
 
 
 @pytest.fixture
-def prefix(db, user):
-    try:
-        p = Prefix.objects.get()
-    except Prefix.DoesNotExist:
-        p = Prefix(user.id)
-        p.save()
-    return p
+def profile(user):
+    return user.profile
 
 
 @pytest.fixture
-def profile(user):
-    return user.profile
+def token(user):
+    return Token.objects.create(user=user).key
 
 
 @pytest.fixture
@@ -48,14 +42,13 @@ def api_secret(settings):
 
 
 @pytest.fixture
-def user_client(api_client, user, prefix):
+def user_client(api_client, user):
     api_client.force_authenticate(user)
     return api_client
 
 
 @pytest.fixture
-def user_api_client(user, api_secret):
+def external_api_client(user, api_secret):
     client = APIClient(HTTP_APISECRET=api_secret)
-    client.force_authenticate(user)
     return client
 

--- a/functional_tests/test_accounts.py
+++ b/functional_tests/test_accounts.py
@@ -6,29 +6,8 @@ def base_url(live_server):
     return live_server.url
 
 
-def test_admin_login(base_url, admin_user, browser):
-    browser.visit('{0}/admin/'.format(base_url))
-    browser.fill_form({'username': 'admin',
-                       'password': 'password'})
-    browser.find_by_value('Log in').click()
-    browser.click_link_by_href('/admin/auth/user/')
-    browser.click_link_by_text('admin')
-    assert 'Storage quota:' in browser.html
-
-
-def test_login_required(base_url, browser):
-    browser.visit('{0}/accounts/profile/'.format(base_url))
-    assert browser.find_by_id('id_username')
-
-
 def test_login(base_url, user, browser):
     browser.visit('{0}/accounts/login/'.format(base_url))
     browser.fill_form({'username': 'qabel_user',
                        'password': 'password'})
     browser.find_by_id('id_submit').click()
-
-    assert 'Storage quota: {0}'.format(user.profile.quota)\
-           == browser.find_by_id('id_quota').first.text
-
-
-

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -17,14 +17,8 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from qabel_provider import views
 
-# noinspection PyCallByClass
-profile = views.ProfileViewSet.as_view({
-    'get': 'retrieve',
-})
-
 rest_urls = [
     url(r'^$', views.api_root, name='api-root'),
-    url(r'^profile/', profile, name='api-profile'),
     url(r'^prefix/', views.PrefixList.as_view(), name='api-prefix'),
     url(r'^auth/', include('rest_auth.urls')),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
@@ -34,7 +28,6 @@ rest_urls = [
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url('^accounts/', include('django.contrib.auth.urls')),
-    url('^accounts/profile', views.profile),
     url(r'^api/v0/', include(rest_urls)),
     url('', include('django_prometheus.urls')),
 ]

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -28,9 +28,7 @@ rest_urls = [
     url(r'^prefix/', views.PrefixList.as_view(), name='api-prefix'),
     url(r'^auth/', include('rest_auth.urls')),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
-    url(r'^auth/(?P<prefix>[\d\w-]+)/(?P<file_path>[\d\w-]+)',
-        views.auth_resource, name='api-auth'),
-    url(r'^quota/', views.quota, name="api-quota"),
+    url(r'^auth/', views.auth_resource, name='api-auth'),
 ]
 
 urlpatterns = [

--- a/qabel_provider/admin.py
+++ b/qabel_provider/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as OriginalUserAdmin
 from django.contrib.auth.models import User
-from .models import Profile, Prefix
+from .models import Profile
 
 
 class UserProfileInline(admin.StackedInline):
@@ -9,13 +9,8 @@ class UserProfileInline(admin.StackedInline):
     can_delete = False
 
 
-class UserPrefixInline(admin.StackedInline):
-    model = Prefix
-    can_delete = False
-
-
 class UserAdmin(OriginalUserAdmin):
-    inlines = [UserProfileInline, UserPrefixInline]
+    inlines = [UserProfileInline]
 
 try:
     admin.site.unregister(User)

--- a/qabel_provider/models.py
+++ b/qabel_provider/models.py
@@ -63,58 +63,10 @@ class Profile(models.Model, ExportModelOperationsMixin('profile')):
                        'Please confirm your e-mail address with this link:',
                        settings.DEFAULT_FROM_EMAIL, [email])
 
+
 @receiver(post_save, sender=User)
 def create_profile_for_new_user(sender, created, instance, **kwargs):
     if created:
         profile = Profile(user=instance)
         profile.save()
 
-
-class Prefix(models.Model, ExportModelOperationsMixin('prefix')):
-    user = models.ForeignKey(User)
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    size = models.PositiveIntegerField(
-        verbose_name="Combined size of all files in the prefix", default=0)
-    downloads = models.PositiveIntegerField(
-        verbose_name="Download traffic from this prefix", default=0
-    )
-
-    @classmethod
-    def get_by_name(cls, name: str):
-        try:
-            prefix_id = uuid.UUID(name)
-        except ValueError:
-            raise Prefix.DoesNotExist("Prefix {} could not be converted to UUID".format(repr(name)))
-        return cls.objects.get(id=prefix_id)
-
-    def __str__(self):
-        return str(self.id)
-
-
-def handle_request(method: str, size: int, prefix: Prefix, user: User):
-    size = int(size)
-    with atomic():
-        if method == 'store':
-            handle_store(size, prefix, user)
-        elif method == 'get':
-            handle_get(size, prefix, user)
-        else:
-            raise TypeError("Method {} not recognized".format(repr(method)))
-
-
-def handle_store(size: int, prefix: Prefix, user: User):
-    profile = user.profile
-    profile.used_storage += size
-    profile.save()
-    prefix.size += size
-    prefix.save()
-
-
-def handle_get(size: int, prefix: Prefix, user: User):
-    if size < 0:
-        raise ValueError('Cannot remove download traffic')
-    prefix.downloads += size
-    prefix.save()
-    profile = user.profile
-    profile.downloads += size
-    profile.save()

--- a/qabel_provider/serializers.py
+++ b/qabel_provider/serializers.py
@@ -17,13 +17,3 @@ class UserSerializer(RegisterSerializer):
         model = User
         fields = ('username', 'email')
         read_only = ('username',)
-
-
-class ProfileSerializer(serializers.ModelSerializer):
-    bucket = serializers.CharField(read_only=True)
-
-    class Meta:
-        model = Profile
-        fields = ('quota', 'bucket', 'used_storage')
-
-

--- a/qabel_provider/serializers.py
+++ b/qabel_provider/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Profile, Prefix
+from .models import Profile
 from django.contrib.auth.models import User
 from rest_auth.registration.serializers import RegisterSerializer
 

--- a/qabel_provider/test_models.py
+++ b/qabel_provider/test_models.py
@@ -18,59 +18,6 @@ def test_superuser(admin_user):
     assert admin_user.profile.quota == 0
 
 
-def test_quote_related_defaults(profile, prefix):
-    assert profile.used_storage == 0
-    assert profile.prefix_downloads == 0
-    assert prefix.size == 0
-    assert prefix.downloads == 0
-
-
-def test_quota_tracking_store(profile, prefix):
-    assert profile.used_storage == 0
-    assert prefix.size == 0
-    models.handle_request('store', SIZE, prefix, prefix.user)
-    profile.refresh_from_db()
-    prefix.refresh_from_db()
-    assert profile.prefix_downloads == 0
-    assert profile.used_storage == SIZE
-    assert prefix.downloads == 0
-    assert prefix.size == SIZE
-
-
-def test_quota_tracking_delete(profile, prefix):
-    models.handle_store(SIZE, prefix, prefix.user)
-    models.handle_request(
-            'store', -SIZE, prefix, prefix.user)
-    profile.refresh_from_db()
-    prefix.refresh_from_db()
-    assert profile.used_storage == 0
-    assert prefix.size == 0
-
-
-def test_quota_tracking_get(profile, prefix):
-    assert profile.downloads == 0
-
-    models.handle_request('get', SIZE, prefix, prefix.user)
-    profile.refresh_from_db()
-    prefix.refresh_from_db()
-
-    # no side effects
-    assert profile.used_storage == 0
-    assert prefix.size == 0
-
-    assert profile.downloads == SIZE
-    assert prefix.downloads == SIZE
-    assert profile.prefix_downloads == SIZE
-
-
-def test_quota_invalid_method(prefix):
-    with pytest.raises(TypeError):
-        models.handle_request('invalid', 0, prefix, prefix.user)
-
-
-def test_prefix_by_str(prefix):
-    assert prefix.id == models.Prefix.get_by_name(str(prefix)).id
-
 
 def test_profile_is_not_confirmed_but_allowed(profile):
     assert profile.is_allowed()

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -120,12 +120,14 @@ def test_auth_resource(external_api_client, user, token):
 
 
 def test_auth_resource_with_disabled_user(external_api_client, user, token):
+    user.profile.is_disabled = True
+    user.profile.save()
     path = '/api/v0/auth/'
     response = external_api_client.post(path, {'auth': 'Token {}'.format(token)})
     assert response.status_code == 200
     data = loads(response.content)
     assert data['user_id'] == user.id
-    assert data['active'] is True
+    assert data['active'] is False
 
 
 def test_auth_resource_invalid_auth_type(external_api_client, token):

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -1,10 +1,9 @@
 import json
 import pytest
-from django.conf import settings
-from django.contrib.auth.models import User
 from datetime import timedelta
 from django.utils import timezone
 from django.core import mail
+from django.contrib.auth.models import User
 
 
 def loads(foo):
@@ -117,7 +116,6 @@ def test_anonymous_profile(api_client):
 
 
 def test_get_own_user(api_client, user):
-    from django.contrib.auth.models import User
     other_user = User.objects.create_user('foobar')
     api_client.force_authenticate(other_user)
     response = api_client.get('/api/v0/auth/user/')
@@ -125,114 +123,82 @@ def test_get_own_user(api_client, user):
         == loads(response.content)
 
 
-def test_get_list_of_user_prefixes(user_client, prefix):
-    response = user_client.get('/api/v0/prefix/')
+def test_auth_resource(external_api_client, user, token):
+    path = '/api/v0/auth/'
+    response = external_api_client.post(path, {'auth': 'Token {}'.format(token)})
     assert response.status_code == 200
-    prefixes = loads(response.content)['prefixes']
-    assert str(prefix.id) == prefixes[0]
+    data = loads(response.content)
+    assert data['user_id'] == user.id
+    assert data['active'] == (not user.profile.is_disabled)
 
 
-def test_create_multiple_prefixes(user_client, user, prefix):
-    response = user_client.post('/api/v0/prefix/')
-    first_prefix = loads(response.content)['prefix']
-    assert response.status_code == 201
-    assert first_prefix != str(prefix.id)
-    response = user_client.post('/api/v0/prefix/')
-    second_prefix = loads(response.content)['prefix']
-    assert response.status_code == 201
-    assert second_prefix != str(prefix.id)
-    assert first_prefix != second_prefix
-    assert user.prefix_set.count() == 3
-    assert {str(prefix.id), first_prefix, second_prefix} ==\
-           set(loads(user_client.get('/api/v0/prefix/').content)['prefixes'])
+def test_auth_resource_with_disabled_user(external_api_client, user, token):
+    path = '/api/v0/auth/'
+    response = external_api_client.post(path, {'auth': 'Token {}'.format(token)})
+    assert response.status_code == 200
+    data = loads(response.content)
+    assert data['user_id'] == user.id
+    assert data['active'] is True
 
 
-def test_anonymous_prefix(api_client):
-    response = api_client.get('/api/v0/prefix/')
-    assert response.status_code == 401
+def test_auth_resource_invalid_auth_type(external_api_client, token):
+    path = '/api/v0/auth/'
+    response = external_api_client.post(path, {'auth': 'Foobar {}'.format(token)})
+    assert response.status_code == 400
+    data = loads(response.content)
+    assert data['error']
 
 
-def test_auth_resource(user_api_client, prefix, api_secret):
-    path = '/api/v0/auth/{}/test'.format(str(prefix.id))
-    response = user_api_client.post(path)
-    assert response.status_code == 204
-    response = user_api_client.get(path)
-    assert response.status_code == 204
-
-    response = user_api_client.delete(path)
-    assert response.status_code == 204
+def test_auth_resource_unknown_user(external_api_client):
+    path = '/api/v0/auth/'
+    response = external_api_client.post(path, {'auth': 'Token foobar'})
+    assert response.status_code == 404
+    data = loads(response.content)
+    assert data['error']
 
 
-def test_failed_auth_resource_requests(user_api_client, user, api_secret):
-    path = '/api/v0/auth/invalid/test'
-    response = user_api_client.post(path)
-    assert response.status_code == 403
-    response = user_api_client.get(path)
-    assert response.status_code == 204
-    response = user_api_client.delete(path)
-    assert response.status_code == 403
+def test_auth_resource_no_body(external_api_client):
+    path = '/api/v0/auth/'
+    response = external_api_client.post(path)
+    assert response.status_code == 400
+    data = loads(response.content)
+    assert data['error']
 
 
-def test_failed_auth_resource_after_7_days(user_api_client, prefix, api_secret, user):
+def test_failed_auth_resource_after_7_days(external_api_client, user, token):
     user.profile.needs_confirmation_after = timezone.now() - timedelta(days=7)
     user.profile.save()
     user.profile.refresh_from_db()
-    path = '/api/v0/auth/{}/test'.format(str(prefix.id))
-    response = user_api_client.post(path)
-    assert response.status_code == 401
-    assert response.content == b'E-Mail address is not confirmed'
+    path = '/api/v0/auth/'
+    request_body = {'auth': 'Token {}'.format(token)}
+    response = external_api_client.post(path, request_body)
+    assert response.status_code == 200
+    data = loads(response.content)
+    assert data['active'] is False
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == 'Please confirm your e-mail address'
     assert mail.outbox[0].body == 'Please confirm your e-mail address with this link:'
 
     # Check, that no new mail is send within 24 hours
-    response = user_api_client.post(path)
-    assert response.status_code == 401
+    response = external_api_client.post(path, request_body)
+    data = loads(response.content)
+    assert data['active'] is False
+    assert response.status_code == 200
     assert len(mail.outbox) == 1
 
     # Check, that a new mail is send after 24 hours
     user.profile.next_confirmation_mail = timezone.now() - timedelta(minutes=1)
     user.profile.save()
     user.profile.refresh_from_db()
-    response = user_api_client.post(path)
-    assert response.status_code == 401
+    response = external_api_client.post(path, request_body)
+    assert response.status_code == 200
     assert len(mail.outbox) == 2
 
 
-def test_auth_resource_api_key(user_client, prefix, api_secret):
-    path = '/api/v0/auth/{}/test'.format(str(prefix.id))
+def test_auth_resource_api_key(user_client):
+    path = '/api/v0/auth/'
     response = user_client.post(path)
     assert response.status_code == 400, "Should require APISECRET header"
-
-
-def test_quota_tracking_post(user_client, prefix, profile, api_secret):
-    path = '/api/v0/quota/'
-    size = 2492
-
-    response = user_client.post(path, {
-        "prefix": str(prefix),
-        "file_path": "foo/bar/baz.txt",
-        "action": "store",
-        "size": size},
-        HTTP_APISECRET=api_secret)
-    assert response.status_code == 204
-    prefix.refresh_from_db()
-    assert prefix.size == size
-    user = prefix.user
-    profile = user.profile
-    assert profile.used_storage == size
-    profile.refresh_from_db()
-
-
-def test_invalid_api_key(user_client, prefix, profile, api_secret):
-    path = '/api/v0/quota/'
-
-    response = user_client.post(path, {
-        "prefix": str(prefix),
-        "file_path": "foo/bar/baz.txt",
-        "action": "store",
-        "size": 1})
-    assert response.status_code == 400
 
 
 def test_logout(api_client, user):

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -102,19 +102,6 @@ def test_get_user(user_client):
         == loads(response.content)
 
 
-def test_get_profile(user_client):
-    response = user_client.get('/api/v0/profile/')
-    assert response.status_code == 200
-    profile = loads(response.content)
-    assert 0 == profile['quota']
-    assert 0 == profile['used_storage']
-
-
-def test_anonymous_profile(api_client):
-    response = api_client.get('/api/v0/profile/')
-    assert response.status_code == 401
-
-
 def test_get_own_user(api_client, user):
     other_user = User.objects.create_user('foobar')
     api_client.force_authenticate(other_user)

--- a/qabel_provider/views.py
+++ b/qabel_provider/views.py
@@ -13,33 +13,14 @@ from rest_framework.views import APIView
 from rest_framework.authtoken.models import Token
 
 from . import models
-from .serializers import ProfileSerializer
 
 logger = logging.getLogger(__name__)
 
 
 @login_required
-def profile(request):
-    return render(request, 'accounts/profile.html')
-
-
-class ProfileViewSet(mixins.RetrieveModelMixin,
-                     mixins.UpdateModelMixin,
-                     viewsets.GenericViewSet):
-    """
-    API endpoint that allows users to be viewed or edited.
-    """
-    serializer_class = ProfileSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-    def get_object(self):
-        return self.request.user.profile
-
-
 @api_view(('GET',))
 def api_root(request, format=None):
     return Response({
-        'profile': reverse('api-profile', request=request, format=format),
         'quota': reverse('api-quota', request=request, format=format),
         'prefix': reverse('api-prefix', request=request, format=format),
         'login': reverse('rest_login', request=request, format=format),


### PR DESCRIPTION
/auth is now called with {'auth': $auth_header} and
responds with {'user_id': user.id, 'active': true}

This corresponds to https://github.com/Qabel/qabel-block/pull/9 and resolves #57 #39