### PR TITLE
Fail silently on sending mails

### DIFF
--- a/qabel_id/settings/base_settings.py
+++ b/qabel_id/settings/base_settings.py
@@ -79,6 +79,8 @@ AXES_LOGIN_FAILURE_LIMIT = 5
 ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL = 'https://qabel.de'
 ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = 'https://qabel.de'
 
+ACCOUNT_ADAPTER = 'qabel_provider.adapters.IgnoreInvalidMailsAdapter'
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',

--- a/qabel_provider/adapters.py
+++ b/qabel_provider/adapters.py
@@ -1,0 +1,8 @@
+from allauth.account.adapter import DefaultAccountAdapter
+
+
+class IgnoreInvalidMailsAdapter(DefaultAccountAdapter):
+
+    def send_mail(self, template_prefix, email, context):
+        msg = self.render_mail(template_prefix, email, context)
+        msg.send(fail_silently=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ django-cors-middleware==1.2.0
 django-axes==1.6.0
 django-redis-cache==1.6.5
 hiredis==0.2.0
+pytest-mock==0.11.0


### PR DESCRIPTION
Configure a new allauth-account adapter which sets the option to fail silently in the mail backend.

Resolves #84