### PR TITLE
auth/info/ API: Return user information by user ID.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,6 @@ def admin(db):
     return u
 
 
-
 @pytest.fixture
 def profile(user):
     return user.profile
@@ -69,4 +68,3 @@ def user_client(api_client, user):
 def external_api_client(user, api_secret):
     client = APIClient(HTTP_APISECRET=api_secret)
     return client
-

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -44,7 +44,7 @@ rest_urls = [
     url(r'^$', views.api_root, name='api-root'),
     url(r'^auth/', include(rest_auth_urls)),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
-    url(r'^auth/$', views.auth_resource, name='api-auth'),
+    url(r'internal/user/$', views.auth_resource, name='api-auth'),
 ]
 
 urlpatterns = [

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -44,7 +44,8 @@ rest_urls = [
     url(r'^$', views.api_root, name='api-root'),
     url(r'^auth/', include(rest_auth_urls)),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
-    url(r'^auth/', views.auth_resource, name='api-auth'),
+    url(r'^auth/$', views.auth_resource, name='api-auth'),
+    url(r'^auth/info/$', views.info_resource, name='api-info'),
 ]
 
 urlpatterns = [

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -45,7 +45,6 @@ rest_urls = [
     url(r'^auth/', include(rest_auth_urls)),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
     url(r'^auth/$', views.auth_resource, name='api-auth'),
-    url(r'^auth/info/$', views.info_resource, name='api-info'),
 ]
 
 urlpatterns = [

--- a/qabel_id/urls.py
+++ b/qabel_id/urls.py
@@ -44,7 +44,7 @@ rest_urls = [
     url(r'^$', views.api_root, name='api-root'),
     url(r'^auth/', include(rest_auth_urls)),
     url(r'^auth/registration/', include('rest_auth.registration.urls')),
-    url(r'internal/user/$', views.auth_resource, name='api-auth'),
+    url(r'^internal/user/$', views.auth_resource, name='api-auth'),
 ]
 
 urlpatterns = [

--- a/qabel_provider/test_rest.py
+++ b/qabel_provider/test_rest.py
@@ -140,7 +140,7 @@ def call_auth_resource(request, external_api_client, user, token, auth_resource_
 
 @pytest.fixture
 def auth_resource_path():
-    return '/api/v0/auth/'
+    return '/api/v0/internal/user/'
 
 
 def test_auth_resource(user, call_auth_resource):

--- a/qabel_provider/views.py
+++ b/qabel_provider/views.py
@@ -43,67 +43,49 @@ def auth_resource(request, format=None):
     """
     Handles auth for uploads, downloads and deletes on the storage backend.
 
+    This returns user data by either passing an authentication token
+    presented by the user (*auth*) or by passing an user ID (*user_id*).
+
+    The first case authenticates the user to the client of this API, the second
+    obviously doesn't.
+
     This resource is meant for the block server which can call it to check
     if the user is authenticated. The block server should set the same
     Authorization header that itself received by the user.
 
-    :return: HttpResponseBadRequest|HttpResponse(status=204)|HttpResponse(status=403)
+    :return: HttpResponseBadRequest|HttpResponse(status=204)|HttpResponse(status=403)|HttpResponse(status=404)
     """
     if not check_api_key(request):
         logger.warning('Called with invalid API key')
         return HttpResponse("Invalid API key", status=400)
 
-    try:
+    if 'auth' in request.data and 'user_id' in request.data:
+        return Response(status=400, data={'error': 'Pass *either* an auth token *or* an user ID'})
+    elif 'auth' in request.data:
         user_auth = request.data['auth']
-    except KeyError:
-        return Response(status=400, data={'error': 'No auth given'})
-    try:
-        auth_type, token = user_auth.split()
-        if auth_type != 'Token':
-            raise ValueError()
-    except ValueError:
-        return Response(status=400, data={'error': 'Invalid auth type'})
-
-    try:
-        token_object = Token.objects.get(key=token)
-    except Token.DoesNotExist:
-        return Response(status=404, data={'error': 'Invalid token'})
-    user = token_object.user
+        try:
+            auth_type, token = user_auth.split()
+            if auth_type != 'Token':
+                raise ValueError()
+        except ValueError:
+            return Response(status=400, data={'error': 'Invalid auth type'})
+        try:
+            user = Token.objects.get(key=token).user
+        except Token.DoesNotExist:
+            return Response(status=404, data={'error': 'Invalid token'})
+    elif 'user_id' in request.data:
+        try:
+            user_id = int(request.data['user_id'])
+        except (KeyError, ValueError):
+            return Response(status=400, data={'error': 'Malformed user ID'})
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            return Response(status=404, data={'error': 'Invalid user ID'})
+    else:
+        return Response(status=400, data={'error': 'No user identification supplied'})
 
     logger.debug('Auth resource called: user={}'.format(user))
-    is_disabled = user.profile.check_confirmation_and_send_mail()
-    return Response({
-        'user_id': user.id,
-        'active': (not is_disabled),
-        'block_quota': user.profile.block_quota,
-        'monthly_traffic_quota': user.profile.monthly_traffic_quota,
-    })
-
-
-@api_view(('POST',))
-def info_resource(request, format=None):
-    """
-    Return user information by user ID.
-
-    Provides access to user information for other services like qabel-block.
-
-    :return: HttpResponseBadRequest|HttpResponse(status=204)|HttpResponse(status=403)
-    """
-    if not check_api_key(request):
-        logger.warning('Called with invalid API key')
-        return HttpResponse('Invalid API key', status=400)
-
-    try:
-        user_id = int(request.data['id'])
-    except (KeyError, ValueError):
-        return Response(status=400, data={'error': 'Malformed user ID'})
-
-    try:
-        user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
-        return Response(status=404, data={'error': 'Invalid user ID'})
-
-    logger.debug('Info resource called: user={}'.format(user))
     is_disabled = user.profile.check_confirmation_and_send_mail()
     return Response({
         'user_id': user.id,

--- a/qabel_provider/views.py
+++ b/qabel_provider/views.py
@@ -47,8 +47,6 @@ def auth_resource(request, format=None):
     if the user is authenticated. The block server should set the same
     Authorization header that itself received by the user.
 
-    :param request: rest request
-    :param format: ignored, because the resource never responds with a body
     :return: HttpResponseBadRequest|HttpResponse(status=204)|HttpResponse(status=403)
     """
     if not check_api_key(request):
@@ -89,8 +87,6 @@ def info_resource(request, format=None):
 
     Provides access to user information for other services like qabel-block.
 
-    :param request: rest request
-    :param format: ignored, because the resource never responds with a body
     :return: HttpResponseBadRequest|HttpResponse(status=204)|HttpResponse(status=403)
     """
     if not check_api_key(request):


### PR DESCRIPTION
This is the API that shall allow completion of qabel/qabel-block#42 /  implementation of qabel/qabel-block#30

It is orthogonal to the auth API, which returns user information via the users auth token: auth/info returns user information via the user ID.