### PR TITLE
inv update: move defaults from invoke.yaml to defaults.yaml

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,5 +1,11 @@
 qabel:
     accounting:
+        DEBUG: False
+        ALLOWED_HOSTS:
+          - '*'
+        API_SECRET: Changeme
+        DEFAULT_FROM_EMAIL: noreply@qabel.de
+        SECRET_KEY: '=tmcici-p92_^_jih9ud11#+wb7*i21firlrtcqh$p+d7o*49@'
         DATABASES:
             default:
                 ENGINE: django.db.backends.postgresql


### PR DESCRIPTION
Rationale

    1. Doesn't take up a spot on the search path
    2. Serves still as an easy example how the config file has to look like
    3. It's not in the code
    4. It's not in the code
    5. It's not in the code
    6. It's not in the code
    ...
    666. It's not in the code

Also set DEBUG=False, ALLOWED_HOSTS=* by default and pull the most
notorious configuration offenders into the defaults.yaml